### PR TITLE
Feature: Dynamically fetch latest Overture Maps release

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,8 +17,11 @@ AGOL_AUTH_METHOD=credentials
 AGOL_USERNAME=your_username
 AGOL_PASSWORD=your_password
 
-# Overture Maps release version (find current release at https://docs.overturemaps.org/)
-OVERTURE_RELEASE=2025-08-20.0
+# Overture Maps release version.
+# Set to "latest" (or leave unset) to auto-resolve the latest release from the
+# Overture STAC catalog at runtime. Pin to a specific release (e.g. 2025-08-20.0)
+# for reproducible runs. See https://docs.overturemaps.org/ for available releases.
+OVERTURE_RELEASE=latest
 
 # DuckDB memory and thread limits — tune to your machine
 DUCKDB_MEMORY_LIMIT=16GB

--- a/src/o2agol/config/settings.py
+++ b/src/o2agol/config/settings.py
@@ -25,6 +25,7 @@ Environment Variables (AGOL_ standard):
 import hashlib
 import logging
 import os
+import requests
 from collections import deque
 from dataclasses import dataclass
 from enum import Enum
@@ -36,6 +37,18 @@ from dotenv import load_dotenv
 
 logger = logging.getLogger(__name__)
 
+# Overture Maps catalog URL for fetching latest release information
+CATALOG_URL = "https://stac.overturemaps.org/catalog.json"
+def get_latest_release():
+    response = requests.get(CATALOG_URL)
+    data = response.json()
+    
+    # The 'latest' field usually contains the most recent version string
+    latest = data.get("latest")
+    
+    # If you specifically want to check if 2026-02-18.0 exists in the history
+    releases = [link['href'] for link in data.get('links', []) if 'releases' in link['href']]
+    return latest, releases
 
 class LogContext(Enum):
     """Context-aware logging levels for pipeline operations."""
@@ -393,7 +406,13 @@ class Config:
     def _load_overture_config(self) -> None:
         """Load Overture Maps configuration with sensible defaults."""
         base_url = os.getenv("OVERTURE_BASE_URL", "s3://overturemaps-us-west-2/release")
-        release = os.getenv("OVERTURE_RELEASE")
+        try:
+            logger.info("Attempting to get latest Overture release from catalog for configuration")
+            release = get_latest_release()[0]  # Get the latest release from the catalog
+        except Exception as e:
+            logger.warning(f"Failed to get latest Overture release from catalog: {e}. Falling back to default.")
+            release = os.getenv("OVERTURE_RELEASE")
+            
         logger.info(f"Config loading OVERTURE_RELEASE from env: {release}")
 
         try:

--- a/src/o2agol/config/settings.py
+++ b/src/o2agol/config/settings.py
@@ -25,30 +25,36 @@ Environment Variables (AGOL_ standard):
 import hashlib
 import logging
 import os
-import requests
 from collections import deque
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
 from typing import Any, Optional
 
+import requests
 from arcgis.gis import GIS
 from dotenv import load_dotenv
 
 logger = logging.getLogger(__name__)
 
-# Overture Maps catalog URL for fetching latest release information
+# Overture Maps STAC catalog endpoint used to resolve the latest release identifier.
 CATALOG_URL = "https://stac.overturemaps.org/catalog.json"
-def get_latest_release():
-    response = requests.get(CATALOG_URL)
-    data = response.json()
-    
-    # The 'latest' field usually contains the most recent version string
-    latest = data.get("latest")
-    
-    # If you specifically want to check if 2026-02-18.0 exists in the history
-    releases = [link['href'] for link in data.get('links', []) if 'releases' in link['href']]
-    return latest, releases
+CATALOG_TIMEOUT_SECONDS = 5.0
+
+
+def get_latest_overture_release(timeout: float = CATALOG_TIMEOUT_SECONDS) -> str:
+    """Return the latest Overture release identifier from the STAC catalog.
+
+    Raises:
+        requests.RequestException: On network failure or non-2xx response.
+        ValueError: If the catalog response omits the 'latest' field.
+    """
+    response = requests.get(CATALOG_URL, timeout=timeout)
+    response.raise_for_status()
+    latest = response.json().get("latest")
+    if not latest:
+        raise ValueError("Overture catalog response missing 'latest' field")
+    return latest
 
 class LogContext(Enum):
     """Context-aware logging levels for pipeline operations."""
@@ -406,14 +412,22 @@ class Config:
     def _load_overture_config(self) -> None:
         """Load Overture Maps configuration with sensible defaults."""
         base_url = os.getenv("OVERTURE_BASE_URL", "s3://overturemaps-us-west-2/release")
-        try:
-            logger.info("Attempting to get latest Overture release from catalog for configuration")
-            release = get_latest_release()[0]  # Get the latest release from the catalog
-        except Exception as e:
-            logger.warning(f"Failed to get latest Overture release from catalog: {e}. Falling back to default.")
-            release = os.getenv("OVERTURE_RELEASE")
-            
-        logger.info(f"Config loading OVERTURE_RELEASE from env: {release}")
+
+        # OVERTURE_RELEASE supports three modes:
+        #   - unset or "latest": resolve dynamically from the Overture STAC catalog
+        #   - explicit release (e.g. "2025-07-23.0"): pin for reproducible runs
+        release = os.getenv("OVERTURE_RELEASE")
+        if release and release.lower() != "latest":
+            logger.info(f"Using pinned Overture release from OVERTURE_RELEASE: {release}")
+        else:
+            try:
+                release = get_latest_overture_release()
+                logger.info(f"Resolved latest Overture release from catalog: {release}")
+            except Exception as e:
+                raise ConfigurationError(
+                    f"Failed to resolve Overture release from catalog ({e}); "
+                    "set OVERTURE_RELEASE to pin a specific release."
+                )
 
         try:
             self.overture = OvertureConfig(


### PR DESCRIPTION
This PR updates the Overture configuration loader to automatically fetch the most recent data release version directly from the official Overture Maps STAC catalog. This removes the need to manually update or hardcode the release version.

**Key Changes:**

- Added requests dependency to fetch external catalog data.

- Introduced a standalone get_latest_release() utility function to parse the latest version string from stac.overturemaps.org/catalog.json.

- Updated _load_overture_config() to prioritize the dynamically fetched release version.

- Added a safe fallback: if the catalog request fails (e.g., due to network issues), the pipeline gracefully falls back to the OVERTURE_RELEASE environment variable.